### PR TITLE
Adding an extra option to suppress rate metrics if so desired

### DIFF
--- a/librato.go
+++ b/librato.go
@@ -222,22 +222,18 @@ func fillInDefaultRateAttrs(r *EnableRateSet) *EnableRateSet {
 
 func addRateAttrs(val RateValue, mType interface{}, name string, self *Reporter) Measurement {
 
-	attrs := func() map[string]interface{} {
-		return map[string]interface{}{
-			DisplayUnitsLong:  Operations,
-			DisplayUnitsShort: OperationsShort,
-			DisplayMin:        "0",
-		}
-	}
-
 	measurement := func(m interface{}, r RateValue, name string, suffix string) Measurement {
 
 		return Measurement{
 			Name: fmt.Sprintf("%s.%s", name, suffix),
 			//If m - metrics.Timer and r is Rate1 then assign metrics.Timer.Rate1
-			Value:      reflect.ValueOf(m).MethodByName(string(r)),
-			Period:     int64(self.Interval.Seconds()),
-			Attributes: attrs(),
+			Value:  reflect.ValueOf(m).MethodByName(string(r)).Call([]reflect.Value{})[0].Float(),
+			Period: int64(self.Interval.Seconds()),
+			Attributes: map[string]interface{}{
+				DisplayUnitsLong:  Operations,
+				DisplayUnitsShort: OperationsShort,
+				DisplayMin:        "0",
+			},
 		}
 	}
 

--- a/librato.go
+++ b/librato.go
@@ -223,10 +223,10 @@ func fillInDefaultRateAttrs(r *EnableRateSet) *EnableRateSet {
 func addRateAttrs(val RateValue, mType interface{}, name string, self *Reporter) Measurement {
 
 	measurement := func(m interface{}, r RateValue, name string, suffix string) Measurement {
-
+		
 		return Measurement{
 			Name: fmt.Sprintf("%s.%s", name, suffix),
-			//If m - metrics.Timer and r is Rate1 then assign metrics.Timer.Rate1
+			//If m - metrics.Timer and r is Rate1 then invoke metrics.Timer.Rate1()
 			Value:  reflect.ValueOf(m).MethodByName(string(r)).Call([]reflect.Value{})[0].Float(),
 			Period: int64(self.Interval.Seconds()),
 			Attributes: map[string]interface{}{

--- a/librato.go
+++ b/librato.go
@@ -100,6 +100,13 @@ func sumSquaresTimer(t metrics.Timer) float64 {
 	return sumSquares
 }
 
+func EmptyEnableRateSet() EnableRateSet {
+	return EnableRateSet{
+		Timer: map[RateValue]bool{},
+		Meter: map[RateValue]bool{},
+	}
+}
+
 func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot Batch, err error) {
 	snapshot = Batch{
 		// coerce timestamps to a stepping fn so that they line up in Librato graphs
@@ -223,7 +230,7 @@ func fillInDefaultRateAttrs(r *EnableRateSet) *EnableRateSet {
 func addRateAttrs(val RateValue, mType interface{}, name string, self *Reporter) Measurement {
 
 	measurement := func(m interface{}, r RateValue, name string, suffix string) Measurement {
-		
+
 		return Measurement{
 			Name: fmt.Sprintf("%s.%s", name, suffix),
 			//If m - metrics.Timer and r is Rate1 then invoke metrics.Timer.Rate1()

--- a/librato_test.go
+++ b/librato_test.go
@@ -53,11 +53,11 @@ func TestNoRateAttrs(t *testing.T) {
 	r := metrics.DefaultRegistry
 	p := NewReporterWithRateOptions(
 		r,
-		EnableRateSet{}, // no rates por favor
-		time.Second*5,   // interval
-		"",              // account owner email address
-		"",              // Librato API token
-		"",              // source
+		EmptyEnableRateSet(), // no rates por favor
+		time.Second*5,           // interval
+		"",                      // account owner email address
+		"",                      // Librato API token
+		"",                      // source
 		[]float64{0.99, 0.90, 0.50}, // percentiles to send
 		time.Millisecond,            // time unit
 	)
@@ -96,11 +96,11 @@ func TestOneRateAttr(t *testing.T) {
 	r := metrics.DefaultRegistry
 	p := NewReporterWithRateOptions(
 		r,
-		EnableRateSet{Timer: map[RateValue]bool{Rate1: true}}, // Set Rate1 on Timer
-		time.Second*5,                                         // interval
-		"",                                                    // account owner email address
-		"",                                                    // Librato API token
-		"",                                                    // source
+		EnableRateSet{Timer: map[RateValue]bool{Rate1: true}, Meter: map[RateValue]bool{}}, // Set Rate1 on Timer
+		time.Second*5, // interval
+		"",            // account owner email address
+		"",            // Librato API token
+		"",            // source
 		[]float64{0.99, 0.90, 0.50}, // percentiles to send
 		time.Millisecond,            // time unit
 	)

--- a/librato_test.go
+++ b/librato_test.go
@@ -1,0 +1,93 @@
+package librato
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+func TestDefaultRateOptions(t *testing.T) {
+	r := metrics.DefaultRegistry
+	p := NewReporter(
+		r,
+		time.Second*5, // interval
+		"",            // account owner email address
+		"",            // Librato API token
+		"",            // source
+		[]float64{0.99, 0.90, 0.50}, // percentiles to send
+		time.Millisecond,            // time unit
+	)
+	ts := time.Now()
+	time.Sleep(5 * time.Millisecond)
+	metrics.GetOrRegisterTimer("test", r).UpdateSince(ts)
+	now := time.Now()
+	b, err := p.BuildRequest(now, r)
+	if err != nil {
+		t.Error("Librato initialization failed with: %v", err)
+	}
+
+	r1, r5, r15 := false, false, false
+
+	for _, g := range b.Gauges {
+		for k, v := range g {
+			if k == "name" {
+				if v == "test.rate.1min" {
+					r1 = true
+				} else if v == "test.rate.5min" {
+					r5 = true
+				} else if v == "test.rate.15min" {
+					r15 = true
+				}
+			}
+		}
+	}
+
+	if !r1 || !r5 || !r15 {
+		t.Error("Expected Timer Rate function - but got none")
+	}
+
+}
+
+func TestNoRateOptions(t *testing.T) {
+	r := metrics.DefaultRegistry
+	p := NewReporterWithRateOptions(
+		r,
+		RateOptions{}, // no rates por favor
+		time.Second*5, // interval
+		"",            // account owner email address
+		"",            // Librato API token
+		"",            // source
+		[]float64{0.99, 0.90, 0.50}, // percentiles to send
+		time.Millisecond,            // time unit
+	)
+	ts := time.Now()
+	time.Sleep(5 * time.Millisecond)
+	metrics.GetOrRegisterTimer("test", r).UpdateSince(ts)
+	now := time.Now()
+	b, err := p.BuildRequest(now, r)
+	if err != nil {
+		t.Error("Librato initialization failed with: %v", err)
+	}
+
+	r1, r5, r15 := false, false, false
+
+	for _, g := range b.Gauges {
+		for k, v := range g {
+			if k == "name" {
+				if v == "test.rate.1min" {
+					r1 = true
+				} else if v == "test.rate.5min" {
+					r5 = true
+				} else if v == "test.rate.15min" {
+					r15 = true
+				}
+			}
+		}
+	}
+
+	if r1 || r5 || r15 {
+		t.Error("Expected No Timer Rate function - but got at least one")
+	}
+
+}


### PR DESCRIPTION
Please take a look. This will save consumers $$. We are trying to weed away with rate metrics as well - since there's ways in librato to do this without client side data.

Basic idea is to allow the users to use a new factory function to pass in specific rate metrics they want instead of giving them no option. A little more democratic :)
