### PR TITLE
Close response body after batch post

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,27 @@ library which will post the metrics to [Librato](https://www.librato.com/). It
 was originally part of the `go-metrics` library itself, but has been split off
 to make maintenance of bith the core library and the client easier.
 
+## ...Fork specific changes and instructions...
+
+### GOMAXPROCS Setting (you might not need to do this)
+If the requests to post metrics are failing, set GOMAXPROCS to something > 1
+See: https://github.com/golang/go/issues/4677
+```
+// Do this at the start of your program
+runtime.GOMAXPROCS(2)
+```
+
+### Librato EOF
+
+Librato servers can't understand the Counter + Gauge json data together for some reason.
+
+Error on librato servers is on the lines of: http://stackoverflow.com/questions/6591388/configure-jackson-to-deserialize-single-quoted-invalid-json
+
+This error is not actually returned by librato on the POST call that contains both Counter and Gauge data. However, the http call
+just causes an EOF. To avoid this problem, this fork sends the Counter and Gauge data as two separate http calls until we can figure out a better solution.
+
+## .../Fork specific changes and instructions...
+
 ### Usage
 
 ```go

--- a/client.go
+++ b/client.go
@@ -90,6 +90,7 @@ func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
 	if resp, err = http.DefaultClient.Do(req); err != nil {
 		return
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var body []byte

--- a/client.go
+++ b/client.go
@@ -129,7 +129,6 @@ func (self *LibratoClient) PostCounters(batch Batch) (err error) {
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
 	}
-	log.Printf("Response from counter data post to Librato: %d %s %s\n", resp.StatusCode, resp.Status, string(body))
 	resp.Body.Close()
 
 	return
@@ -170,7 +169,6 @@ func (self *LibratoClient) PostGauges(batch Batch) (err error) {
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
 	}
-	log.Printf("Response from gauge data post to Librato: %d %s %s\n", resp.StatusCode, resp.Status, string(body))
 	resp.Body.Close()
 
 	return

--- a/client.go
+++ b/client.go
@@ -116,6 +116,7 @@ func (self *LibratoClient) PostCounters(batch Batch) (err error) {
 
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(self.Email, self.Token)
+	req.Close = true
 
 	if resp, err = http.DefaultClient.Do(req); err != nil {
 		log.Printf("Error Return. %s\n", err)
@@ -156,6 +157,7 @@ func (self *LibratoClient) PostGauges(batch Batch) (err error) {
 
 	req.Header.Set("Content-Type", "application/json")
 	req.SetBasicAuth(self.Email, self.Token)
+	req.Close = true
 
 	if resp, err = http.DefaultClient.Do(req); err != nil {
 		log.Printf("Error Return. %s\n", err)

--- a/client.go
+++ b/client.go
@@ -3,8 +3,10 @@ package librato
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 )
 
@@ -65,18 +67,46 @@ type Batch struct {
 	Source      string        `json:"source"`
 }
 
+// Seems like librato doesn't like us sending gauges and counters together
+// Split the structs to send two json batches.
+type GaugeBatch struct {
+	Gauges []Measurement `json:"gauges,omitempty"`
+}
+
+type CounterBatch struct {
+	Counters []Measurement `json:"counters,omitempty"`
+}
+
 func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
+
+	var counterErr error
+	if len(batch.Counters) > 0 {
+		counterErr = self.PostCounters(batch)
+	}
+
+	var gaugeErr error
+	if len(batch.Gauges) > 0 {
+		gaugeErr = self.PostGauges(batch)
+	}
+	if counterErr != nil || gaugeErr != nil {
+		return errors.New(fmt.Sprintf("Metrics post error. Gauge post error: %v Counter post error: %v", gaugeErr, counterErr))
+	}
+	return
+}
+
+func (self *LibratoClient) PostCounters(batch Batch) (err error) {
 	var (
 		js   []byte
 		req  *http.Request
 		resp *http.Response
 	)
 
-	if len(batch.Counters) == 0 && len(batch.Gauges) == 0 {
-		return nil
+	for i := 0; i < len(batch.Counters); i++ {
+		batch.Counters[i]["source"] = batch.Source
+		batch.Counters[i]["measure_time"] = batch.MeasureTime
 	}
-
-	if js, err = json.Marshal(batch); err != nil {
+	counterBatch := CounterBatch{batch.Counters}
+	if js, err = json.Marshal(counterBatch); err != nil {
 		return
 	}
 
@@ -88,16 +118,60 @@ func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
 	req.SetBasicAuth(self.Email, self.Token)
 
 	if resp, err = http.DefaultClient.Do(req); err != nil {
+		log.Printf("Error Return. %s\n", err)
 		return
 	}
-	defer resp.Body.Close()
 
+	var body []byte
+	if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
+	}
 	if resp.StatusCode != http.StatusOK {
-		var body []byte
-		if body, err = ioutil.ReadAll(resp.Body); err != nil {
-			body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
-		}
 		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
 	}
+	log.Printf("Response from counter data post to Librato: %d %s %s\n", resp.StatusCode, resp.Status, string(body))
+	resp.Body.Close()
+
+	return
+}
+
+func (self *LibratoClient) PostGauges(batch Batch) (err error) {
+	var (
+		js   []byte
+		req  *http.Request
+		resp *http.Response
+	)
+
+	for i := 0; i < len(batch.Gauges); i++ {
+		batch.Gauges[i]["source"] = batch.Source
+		batch.Gauges[i]["measure_time"] = batch.MeasureTime
+	}
+
+	gaugeBatch := GaugeBatch{batch.Gauges}
+	if js, err = json.Marshal(gaugeBatch); err != nil {
+		return
+	}
+	if req, err = http.NewRequest("POST", MetricsPostUrl, bytes.NewBuffer(js)); err != nil {
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.SetBasicAuth(self.Email, self.Token)
+
+	if resp, err = http.DefaultClient.Do(req); err != nil {
+		log.Printf("Error Return. %s\n", err)
+		return
+	}
+
+	var body []byte
+	if body, err = ioutil.ReadAll(resp.Body); err != nil {
+		body = []byte(fmt.Sprintf("(could not fetch response body for error: %s)", err))
+	}
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("Unable to post to Librato: %d %s %s", resp.StatusCode, resp.Status, string(body))
+	}
+	log.Printf("Response from gauge data post to Librato: %d %s %s\n", resp.StatusCode, resp.Status, string(body))
+	resp.Body.Close()
+
 	return
 }


### PR DESCRIPTION
"The client must close the response body when finished with it"

resp, err := http.Get("http://example.com/")
if err != nil {
    // handle error
}
defer resp.Body.Close()
body, err := ioutil.ReadAll(resp.Body)

https://golang.org/pkg/net/http/#Transport
