### PR TITLE
Read the entire HTTP response and close it

### DIFF
--- a/client.go
+++ b/client.go
@@ -90,6 +90,7 @@ func (self *LibratoClient) PostMetrics(batch Batch) (err error) {
 	if resp, err = http.DefaultClient.Do(req); err != nil {
 		return
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		var body []byte


### PR DESCRIPTION
If the response isn't closed, we have a resource leak. Originally spotted by
@urjitbhatia in #5.
