### PR TITLE
Provide a per-minute reporting examplea

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ to make maintenance of both the core library and the client easier.
 import "github.com/mihasya/go-metrics-librato"
 
 go librato.Librato(metrics.DefaultRegistry,
-    10e9,                  // interval
+    1 * time.Minute,       // interval
     "example@example.com", // account owner email address
     "token",               // Librato API token
     "hostname",            // source
     []float64{0.95},       // percentiles to send
-    time.Millisecond,      // time unit
+    time.Minute,           // time unit
 )
 ```
 


### PR DESCRIPTION
I was seeing some `divide by zero` panics when trying other reporting intervals/durations for the periodic reporting to librato. I changed the project using this to 1 minute (same config as in this PR) and am seeing things work much nicer. I figured I'd PR this back so others could get a working config up and going. 
